### PR TITLE
fix: hot-fix for issue-oc-28337

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/OptimizationPool.cs
+++ b/src/AngleSharp.Core.Tests/Library/OptimizationPool.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Core.Tests.Library
+namespace AngleSharp.Core.Tests.Library
 {
     using AngleSharp.Text;
     using NUnit.Framework;
@@ -29,6 +29,7 @@
 
             StringBuilderPool.MaxCount = _defaultCount;
             StringBuilderPool.SizeLimit = _defaultLimit;
+            StringBuilderPool.IsPoolingDisabled = false;
         }
 
         [Test]
@@ -55,6 +56,19 @@
             var sb2 = StringBuilderPool.Obtain();
             Assert.AreEqual(String.Empty, sb2.ToPool());
             Assert.AreSame(sb1, sb2);
+        }
+
+        [Test]
+        public void RecycleStringBuilderGetString_DisabledPooling()
+        {
+            StringBuilderPool.IsPoolingDisabled = true;
+            var str = "Test";
+            var sb1 = StringBuilderPool.Obtain();
+            sb1.Append(str);
+            Assert.AreEqual(str, sb1.ToPool());
+            var sb2 = StringBuilderPool.Obtain();
+            Assert.AreEqual(String.Empty, sb2.ToPool());
+            Assert.AreNotSame(sb1, sb2);
         }
 
         [Test]


### PR DESCRIPTION
This is a hot fix for **#issue-oc-28337**.

The original PR in AngleSharp is here: https://github.com/AngleSharp/AngleSharp/pull/1203

>Added a new setting for disabling Stringbuilder pooling. This can increase performance during heavy parallel processing as it will skip the lock. However, by disabling pooling it can also increase overall memory consumption.